### PR TITLE
reproduce big int number conversion error

### DIFF
--- a/sandbox/prisma/migration.sql
+++ b/sandbox/prisma/migration.sql
@@ -48,7 +48,7 @@ CREATE TABLE "type_test_2" (
     "id" TEXT NOT NULL,
     "datetime_column" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "datetime_column_null" TIMESTAMP(3),
-
+    "bigint_column" BIGINT NOT NULL DEFAULT 0,
     CONSTRAINT "type_test_2_pkey" PRIMARY KEY ("id")
 );
 

--- a/sandbox/prisma/schema.prisma
+++ b/sandbox/prisma/schema.prisma
@@ -50,6 +50,7 @@ model type_test_2 {
   id                   String    @id @default(cuid())
   datetime_column      DateTime  @default(now()) @db.Timestamp(3)
   datetime_column_null DateTime? @db.Timestamp(3)
+  bigint_column        BigInt    @default(0)
 }
 
 model Child {

--- a/sandbox/src/test.ts
+++ b/sandbox/src/test.ts
@@ -24,6 +24,7 @@ export async function smokeTest(adapter: DriverAdapter) {
   await test.testCreateAndDeleteChildParent();
   await test.interactiveTransactions();
   await test.explicitTransaction();
+  await test.testBigInt();
 
   console.log("[nodejs] disconnecting...");
   await prisma.$disconnect();
@@ -239,5 +240,15 @@ class SmokeTest {
       "[nodejs] resultDeleteMany",
       superjson.serialize(resultDeleteMany).json
     );
+  }
+
+  async testBigInt() {
+    const result = await this.prisma.type_test_2.create({
+      data: {
+        bigint_column: 17435114878,
+      },
+    });
+
+    console.log("[nodejs] testBigInt result", superjson.serialize(result).json);
   }
 }


### PR DESCRIPTION
Running tests will give throw this error: 

```
245 async testBigInt() {
→ 246   const result = await this.prisma.type_test_2.create(
Inconsistent column data: Conversion failed: number must be an integer in column 'bigint_column', got '17435114878.0'
```